### PR TITLE
Add option to control whether or not a browser will be opened.

### DIFF
--- a/bin/swagger-ui-watcher.js
+++ b/bin/swagger-ui-watcher.js
@@ -15,7 +15,8 @@ program
     .option('-p, --port <port>', 'Port to be used. Default is 8000')
     .option('-h, --host <Hostname|Ip>', 'Host to be used. Default is 127.0.0.1')
     .option('-b, --bundle <bundleTo>', 'Create bundle and save it to bundleTo')
-    .option('-o, --open', 'Open the view page in the default browser')
+    // '--no-open' sets `program.open`, regardless of whether the option was passed
+    .option('--no-open', 'Do not open the view page in the default browser')
     .action(function(swaggerFile, targetDir) {
         swaggerFileValue = swaggerFile;
         targetDirValue = targetDir;
@@ -49,10 +50,6 @@ if (typeof program.host === 'undefined') {
 
 if (typeof program.bundle === 'undefined') {
     program.bundle = null;
-}
-
-if (program.open !== true) {
-  program.open = false;
 }
 
 if (program.bundle === swaggerFileValue) {

--- a/bin/swagger-ui-watcher.js
+++ b/bin/swagger-ui-watcher.js
@@ -9,13 +9,16 @@ var swaggerFileValue;
 var targetDirValue;
 var help = 'Enter "swagger-ui-watcher --help" for more details.';
 
+/*
+ * NOTE: the '--no-open' option will set its inverse counterpart `program.open`;
+ * this will always be set accordingly, see https://github.com/tj/commander.js#option-parsing.
+ */
 program
     .version(version)
     .arguments('<swaggerFile> [targetDir]')
     .option('-p, --port <port>', 'Port to be used. Default is 8000')
     .option('-h, --host <Hostname|Ip>', 'Host to be used. Default is 127.0.0.1')
     .option('-b, --bundle <bundleTo>', 'Create bundle and save it to bundleTo')
-    // '--no-open' sets `program.open`, regardless of whether the option was passed
     .option('--no-open', 'Do not open the view page in the default browser')
     .action(function(swaggerFile, targetDir) {
         swaggerFileValue = swaggerFile;

--- a/bin/swagger-ui-watcher.js
+++ b/bin/swagger-ui-watcher.js
@@ -15,6 +15,7 @@ program
     .option('-p, --port <port>', 'Port to be used. Default is 8000')
     .option('-h, --host <Hostname|Ip>', 'Host to be used. Default is 127.0.0.1')
     .option('-b, --bundle <bundleTo>', 'Create bundle and save it to bundleTo')
+    .option('-o, --open', 'Open the view page in the default browser')
     .action(function(swaggerFile, targetDir) {
         swaggerFileValue = swaggerFile;
         targetDirValue = targetDir;
@@ -50,6 +51,10 @@ if (typeof program.bundle === 'undefined') {
     program.bundle = null;
 }
 
+if (program.open !== true) {
+  program.open = false;
+}
+
 if (program.bundle === swaggerFileValue) {
     console.error("<bundle> value cannot be same as <swaggerFile> value.");
     process.exit(1);
@@ -70,7 +75,8 @@ if (program.bundle === null) {
         swaggerFileValue,
         targetDirValue,
         program.port,
-        program.host
+        program.host,
+        program.open
     );
 } else {
     require("../index.js").build(

--- a/index.js
+++ b/index.js
@@ -69,8 +69,9 @@ function start(swaggerFile, targetDir, port, hostname, openBrowser) {
   });
 
   server.listen(port,hostname, function() {
-    console.log(`Listening on ${hostname}:${port}`);
-    if (openBrowser) open('http://' + hostname + ':' + port);
+    var serverUrl = `http://${hostname}:${port}`;
+    console.log(`Listening on ${serverUrl}`);
+    if (openBrowser) open(serverUrl);
   });
 }
 

--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ function bundle(swaggerFile) {
   });
 }
 
-function start(swaggerFile, targetDir, port, hostname, bundleTo) {
+function start(swaggerFile, targetDir, port, hostname, openBrowser) {
   app.get('/', function(req, res) {
     res.sendFile(__dirname + "/index.html");
   });
@@ -48,7 +48,7 @@ function start(swaggerFile, targetDir, port, hostname, bundleTo) {
     next();
   });
 
-  io.on('connection', function(socket) {  
+  io.on('connection', function(socket) {
     socket.on('uiReady', function(data) {
       bundle(swaggerFile).then(function (bundled) {
         socket.emit('updateSpec', JSON.stringify(bundled));
@@ -69,7 +69,8 @@ function start(swaggerFile, targetDir, port, hostname, bundleTo) {
   });
 
   server.listen(port,hostname, function() {
-    open('http://' + hostname + ':' + port);
+    console.log(`Listening on ${hostname}:${port}`);
+    if (openBrowser) open('http://' + hostname + ':' + port);
   });
 }
 


### PR DESCRIPTION
Since I mostly keep a tab opened (in a non-default browser too), I prefer the watcher to not open a window by itself.

This commit adds an option '-o, --open' causing a browser window to be opened (i.e. it will not be opened by default anymore). This feels the most intuitive to me, but of course the logic could be inverted.