### PR TITLE
Does not throw error when local ref is missing

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ function bundle(swaggerFile) {
   return JsonRefs.resolveRefs(root, options).then(function (results) {
     var resErrors = {};
     for (const [k,v] of Object.entries(results.refs)) {
-      if ('missing' in v && v.missing === true)
+      if ('missing' in v && v.missing === true && (v.type == 'relative' || v.type === 'remote'))
         resErrors[k] = v.error;
     }
 


### PR DESCRIPTION
## Problem:

Swagger-ui-watcher stopped working with local references

## Example:

We have two files -- main and a file that is referenced in the main file.
The referenced file uses a schema that is defined in the main file.

**openapi.yaml**
```
openapi: "3.0.0"
info:
  version: 1.0.0
  title: Swagger Petstore
  license:
    name: MIT
servers:
  - url: http://petstore.swagger.io/v1
paths:
  /pets:
    get:
      $ref: "./example.yaml"
components:
  schemas:
    Pet:
      required:
        - id
        - name
      properties:
        id:
          type: integer
          format: int64
        name:
          type: string
        tag:
          type: string
```

**example.yaml**

```
      summary: List all pets
      operationId: listPets
      tags:
        - pets
      parameters:
        - name: limit
          in: query
          description: How many items to return at one time (max 100)
          required: false
          schema:
            type: integer
            format: int32
      responses:
        '200':
          description: A paged array of pets
          headers:
            x-next:
              description: A link to the next page of responses
              schema:
                type: string
          content:
            application/json:    
              schema:
                $ref: "#/components/schemas/Pet"
```

Running the main file will throw the following error
```
  
There was an error while processing your files. Please fix the error and save the file.

  
#/paths/~1pets/get/responses/200/content/application~1json/schema: JSON Pointer points to missing location: #/components/schemas/Pet

```

## Cause

We added additional error checking logic to display more detailed error (https://github.com/moon0326/swagger-ui-watcher/blob/master/index.js#L39). However, we also defined "filter" option of json-refs package to only resolve relative and remote files. After the change, any local references (staring with #) started throwing errors since they are considered missing.

## Solution

Ignore missing local references  with this change.