### PR TITLE
Version of swagger-editor-dist was bumped to 3.6.20

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ Swagger UI Watcher detects changes in your local Swagger files and reload Swagge
 ## Installation
 
 | Version | Swagger Version |
-|--------|--------|
-|  1.0.10      |   2     |
-|  2.0 | 3 |
+|---------|-----------------|
+| 1.0.10  | 2               |
+| >=2.0   | 3               |
 
 
 ```

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "opn": "5.3.0",
     "path": "^0.12.7",
     "socket.io": "^2.0.3",
-    "swagger-editor-dist": "3.6.0"
+    "swagger-editor-dist": "3.6.20"
   },
   "bin": {
     "swagger-ui-watcher": "bin/swagger-ui-watcher.js"


### PR DESCRIPTION
This version contains a fix for correctly describing request body in form-url-encoding format. Affects OpenApi 3.0