### PR TITLE
Allow to exclude paths or files from watch

### DIFF
--- a/bin/swagger-ui-watcher.js
+++ b/bin/swagger-ui-watcher.js
@@ -8,6 +8,7 @@ var path = require('path');
 var swaggerFileValue;
 var targetDirValue;
 var swaggerUIOptions = {};
+var watchIgnore = undefined;
 var help = 'Enter "swagger-ui-watcher --help" for more details.';
 
 /*
@@ -22,6 +23,7 @@ program
     .option('-b, --bundle <bundleTo>', 'Create bundle and save it to bundleTo')
     .option('--no-open', 'Do not open the view page in the default browser')
     .option('-c, --config <JSON file>', 'Path to json file containing swagger ui options')
+    .option('-i, --ignore <matches>', 'File or path omitted from watching')
     .action(function(swaggerFile, targetDir) {
         swaggerFileValue = swaggerFile;
         targetDirValue = targetDir;
@@ -62,6 +64,10 @@ if (program.bundle === swaggerFileValue) {
     process.exit(1);
 }
 
+if (program.ignore) {
+    watchIgnore = path.resolve(program.ignore);
+}
+
 if (!fs.existsSync(targetDirValue)) {
     console.error(targetDirValue + " does not exist.");
     process.exit(1);
@@ -83,7 +89,8 @@ if (program.bundle === null) {
         program.port,
         program.host,
         program.open,
-        swaggerUIOptions
+        swaggerUIOptions,
+        watchIgnore
     );
 } else {
     require("../index.js").build(

--- a/index.js
+++ b/index.js
@@ -55,7 +55,7 @@ function bundle(swaggerFile) {
   });
 }
 
-function start(swaggerFile, targetDir, port, hostname, openBrowser, swaggerUIOptions) {
+function start(swaggerFile, targetDir, port, hostname, openBrowser, swaggerUIOptions, watchIgnore) {
   app.get('/', function(req, res) {
     res.sendFile(__dirname + "/index.html");
   });
@@ -80,7 +80,7 @@ function start(swaggerFile, targetDir, port, hostname, openBrowser, swaggerUIOpt
     });
   });
 
-  chokidar.watch(targetDir).on('change', function(eventType, name) {
+  chokidar.watch(targetDir, {ignored: watchIgnore}).on('change', function(eventType, name) {
     bundle(swaggerFile).then(function (bundled) {
       console.log("File changed. Sent updated spec to the browser.");
       var bundleString = JSON.stringify(bundled, null, 2);


### PR DESCRIPTION
With this change it is possible to specify a file or a path to be ignored by chokidar.

Typical use case is to ignore _node_modules_ if it happens to exist in `targetDirValue`. Watching of _node_modules_ may cause the following error:

```
Listening on http://127.0.0.1:8000
node:internal/errors:496
    ErrorCaptureStackTrace(err);
    ^

Error: ENOSPC: System limit for number of file watchers reached, watch [...]
```

Added functionality allows to overcome this issue.