### PR TITLE
-i/--ignore option description added to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ swagger-ui-watcher ./main-swagger-file.json
 | --no-open                    | Do not open the view page in the default browser                                                                                                                              |
 | -c --config <JSON_file>      | JSON file containing any of the [Swagger UI options](https://github.com/swagger-api/swagger-ui/blob/master/docs/usage/configuration.md). Example: `{"withCredentials": true}` |
 | -b --bundle <bundleLocation> | Create bundle at the specified location                                                                                                                                       |
+| -i --ignore <matches>        | File or path omitted from watching. Supports globbing                                                                                                                         |
 
 For creating the bundled file, provide the optional argument `bundle`
 


### PR DESCRIPTION
Continuation of PR #68.

Supplements the readme file with a description of new command line argument: `-i/--ignore`.